### PR TITLE
explicitly get column dtypes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ raw_data/
 *Zone.Identifier
 willitfit/keys
 willitfit/data/*.csv
+
+*.deb*

--- a/willitfit/app_utils/googlecloud.py
+++ b/willitfit/app_utils/googlecloud.py
@@ -23,8 +23,19 @@ def get_cloud_data(path_to_file=f"{DATA_FOLDER}/{CAR_DATABASE}"):
     # Set environment variable for service account
     set_environment_variable()
 
+    # Make sure the column types are set properly
+    dtype_dict = {
+        "width": int,
+        "height": int,
+        "length": int,
+        "weight": float,
+        "packages": int,
+        "subarticle_code": str,
+        "article_code": str,
+        "product_name": str
+    }
     # Read and return data
-    return pd.read_csv(f"gs://{BUCKET_NAME}/{path_to_file}")
+    return pd.read_csv(f"gs://{BUCKET_NAME}/{path_to_file}",dtype=dtype_dict)
 
 
 def send_cloud_data(df, path_to_file="data/test.csv"):


### PR DESCRIPTION
 to avoid misreading articles that start with 0s
fixes #95 